### PR TITLE
Updates for modern GitHub

### DIFF
--- a/src/cautoupdatergithub.cpp
+++ b/src/cautoupdatergithub.cpp
@@ -135,11 +135,11 @@ void CAutoUpdaterGithub::updateCheckRequestFinished()
 	}
 
 	ChangeLog changelog;
-	const QString changelogPattern = QStringLiteral("<div class=\"markdown-body\">\n*</div>");
+	const QString changelogPattern = QStringLiteral("<div class=\"markdown-body my-3\">*</div>");
 	const QString versionPattern = QStringLiteral("/releases/tag/*\">");
 	const QString releaseUrlPattern = QStringLiteral("<a href=\"*\"");
 
-	const auto releases = QString(reply->readAll()).split("release-header");
+	const auto releases = QString(reply->readAll()).split("release-card");
 	// Skipping the 0 item because anything before the first "release-header" is not a release
 	for (int releaseIndex = 1, numItems = releases.size(); releaseIndex < numItems; ++releaseIndex)
 	{
@@ -147,6 +147,8 @@ void CAutoUpdaterGithub::updateCheckRequestFinished()
 
 		int offset = 0;
 		QString updateVersion = match(versionPattern, releaseText, offset, offset);
+		QString urlToUpdatePage = _updatePageAddress + "tag/" + updateVersion;
+			
 		if (updateVersion.startsWith(QStringLiteral(".v")))
 			updateVersion.remove(0, 2);
 		else if (updateVersion.startsWith('v'))
@@ -169,8 +171,8 @@ void CAutoUpdaterGithub::updateCheckRequestFinished()
 			}
 		}
 
-		if (!url.isEmpty())
-			changelog.push_back({ updateVersion, updateChanges, "https://github.com" + url });
+		// GitHub seems to dynamically add assets, which don't show up in the html, so we provide a link to the release page instead
+		changelog.push_back({ updateVersion, updateChanges, !url.isEmpty() ? "https://github.com" + url : urlToUpdatePage });
 	}
 
 	if (_listener)

--- a/src/cautoupdatergithub.cpp
+++ b/src/cautoupdatergithub.cpp
@@ -11,14 +11,6 @@ RESTORE_COMPILER_WARNINGS
 
 #include <assert.h>
 
-#if defined _WIN32
-#define UPDATE_FILE_EXTENSION QLatin1String(".exe")
-#elif defined __APPLE__
-#define UPDATE_FILE_EXTENSION QLatin1String(".dmg")
-#else
-#define UPDATE_FILE_EXTENSION QLatin1String(".AppImage")
-#endif
-
 static const auto naturalSortQstringComparator = [](const QString& l, const QString& r) {
 	static QCollator collator;
 	collator.setNumericMode(true);

--- a/src/cautoupdatergithub.cpp
+++ b/src/cautoupdatergithub.cpp
@@ -127,8 +127,8 @@ void CAutoUpdaterGithub::updateCheckRequestFinished()
 	}
 
 	ChangeLog changelog;
-	const QString changelogPattern = QStringLiteral("<div class=\"markdown-body my-3\">*</div>");
-	const QString versionPattern = QStringLiteral("/releases/tag/*\">");
+    	const QString changelogPattern = QStringLiteral("markdown-body my-3\">*</div>");
+    	const QString versionPattern = QStringLiteral("/releases/tag/*\"");
 	const QString releaseUrlPattern = QStringLiteral("<a href=\"*\"");
 
 	const auto releases = QString(reply->readAll()).split("release-card");

--- a/src/cautoupdatergithub.h
+++ b/src/cautoupdatergithub.h
@@ -11,6 +11,14 @@ RESTORE_COMPILER_WARNINGS
 #include <functional>
 #include <vector>
 
+#if defined _WIN32
+#define UPDATE_FILE_EXTENSION QLatin1String(".exe")
+#elif defined __APPLE__
+#define UPDATE_FILE_EXTENSION QLatin1String(".dmg")
+#else
+#define UPDATE_FILE_EXTENSION QLatin1String(".AppImage")
+#endif
+
 class CAutoUpdaterGithub final : public QObject
 {
 public:

--- a/src/updaterUI/cupdaterdialog.cpp
+++ b/src/updaterUI/cupdaterdialog.cpp
@@ -42,7 +42,7 @@ CUpdaterDialog::~CUpdaterDialog()
 void CUpdaterDialog::applyUpdate()
 {
 #ifdef _WIN32
-	if (_latestUpdateUrl.endsWith("exe"))
+	if (_latestUpdateUrl.endsWith(UPDATE_FILE_EXTENSION))
 	{
 		ui->progressBar->setMaximum(100);
 		ui->progressBar->setValue(0);

--- a/src/updaterUI/cupdaterdialog.cpp
+++ b/src/updaterUI/cupdaterdialog.cpp
@@ -42,13 +42,19 @@ CUpdaterDialog::~CUpdaterDialog()
 void CUpdaterDialog::applyUpdate()
 {
 #ifdef _WIN32
-	ui->progressBar->setMaximum(100);
-	ui->progressBar->setValue(0);
-	ui->lblPercentage->setVisible(true);
-	ui->lblOperationInProgress->setText("Downloading the update...");
-	ui->stackedWidget->setCurrentIndex(0);
+	if (_latestUpdateUrl.endsWith("exe"))
+	{
+		ui->progressBar->setMaximum(100);
+		ui->progressBar->setValue(0);
+		ui->lblPercentage->setVisible(true);
+		ui->lblOperationInProgress->setText("Downloading the update...");
+		ui->stackedWidget->setCurrentIndex(0);
 
-	_updater.downloadAndInstallUpdate(_latestUpdateUrl);
+		_updater.downloadAndInstallUpdate(_latestUpdateUrl);
+	} else {
+		QDesktopServices::openUrl(QUrl(_latestUpdateUrl));
+		accept();
+	}
 #else
 	QMessageBox msg(
 		QMessageBox::Question,


### PR DESCRIPTION
*cautoupdatergithub.cpp* 
- Updated patterns to work again
- Added a fallback to serve the release page instead of an installer download, since it doesn't seem like downloads can be found in the .html anymore
- Moved UPDATE_FILE_EXTENSION definition to the header file instead

*cupdaterdialog.cpp*
- Added a fallback to open the release page in browser if an installer isn't received